### PR TITLE
Hot fix for HTMX Price History table in product_detail.html

### DIFF
--- a/main_app/templates/htmx/update_price_table.html
+++ b/main_app/templates/htmx/update_price_table.html
@@ -3,6 +3,7 @@
         <tr>
             <td>{{ entry.timestamp }}</td>
             <td>${{ entry.price }}</td>
+            <td>{{ entry.retailer.name }}</td>
         </tr>
     {% endfor %}
 </tbody>

--- a/main_app/templates/products/product_detail.html
+++ b/main_app/templates/products/product_detail.html
@@ -74,6 +74,7 @@
                         <tr>
                             <th>Date</th>
                             <th>Price</th>
+                            <th>Sold By:</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -81,6 +82,7 @@
                             <tr>
                                 <td>{{ entry.timestamp }}</td>
                                 <td>${{ entry.price }}</td>
+                                <td>{{ entry.retailer.name }}</td>
                             </tr>
                         {% endfor %}
                     </tbody>


### PR DESCRIPTION
This pull request includes updates to the price history table in the product detail page to include the retailer information. The changes ensure that the retailer's name is displayed alongside the price and date.

## Updates to price history table:

* [`main_app/templates/htmx/update_price_table.html`](diffhunk://#diff-6b5c48ebfed5ba4fe79a70ddd43f74ad359f8c656225da48104f5c40a6191205R6): Added a new table cell to display the retailer's name for each entry in the price history.
* [`main_app/templates/products/product_detail.html`](diffhunk://#diff-cc7c3a923f1eed7c70578ec7f595811a32d00f78df4c1797c7f334b0a42fd1a2R77-R85): Added a new header cell "Sold By:" and a new table cell to display the retailer's name for each entry in the price history.